### PR TITLE
Improve type definition for the default exported function.

### DIFF
--- a/src/main/utils/basic.ts
+++ b/src/main/utils/basic.ts
@@ -180,12 +180,9 @@ export function dashToCamel(str: string): string {
     }
 }
 
-export function memoize<A>(fn: () => A): () => A
-export function memoize<A, B>(fn: (a: A) => B): (a: A) => B
-export function memoize<A, B, C>(fn: (a: A, b: B) => C): (a: A, b: B) => C
-export function memoize(fn: (...args: Array<any>) => any): (...args: Array<any>) => any {
+export function memoize<A extends Array<any>, B>(fn: (...args: A) => B): (...args: A) => B {
     let cachedValue: any
-    return (...args: Array<any>) => {
+    return (...args) => {
         if (cachedValue === undefined) {
             cachedValue = fn(...args)
         }


### PR DESCRIPTION
## Description

Previously due to the way `Utils.memoize` was overloaded, the generated index.d.ts file had its default export as a 0-arity function:

```typescript
declare const config: () => DynamicConfig
```

However in reality (at runtime) it's possible to pass an `IConfigOptions` object to this function.

This changeset tweaks the way `Utils.memoize` is typed to produce a more accurate type definition for the config function:

```typescript
declare const config: (options?: IConfigOptions | undefined) => DynamicConfig
```

For more info about how/why this works, see: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#generic-rest-parameters

## Motivation and Context
Previously users of this library had no way to pass config options without either subverting the type system or constructing a `DynamicConfig` object themselves. I confirmed with @kevin-greene-ck separately that passing in options should be available to users of this library, so this change makes it possible without hacks. :tada:

## How Has This Been Tested?
Verified that after these changes it is possible to pass options from client code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.