### PR TITLE
Typescript is not a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
         "typescript": "3.5.x",
         "wait-on": "^3.2.0"
     },
+    "peerDependencies": {
+        "typescript": ">=3.5.0"
+    },
     "dependencies": {
         "@creditkarma/consul-client": "^0.8.4",
         "@creditkarma/vault-client": "^0.5.11",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "prettier": "^1.18.2",
         "request-promise-native": "^1.0.7",
         "rimraf": "^2.6.3",
+        "typescript": "3.5.x",
         "wait-on": "^3.2.0"
     },
     "dependencies": {
@@ -60,7 +61,6 @@
         "@creditkarma/vault-client": "^0.5.11",
         "@types/yamljs": "^0.2.30",
         "ajv": "^6.10.2",
-        "typescript": "3.5.x",
         "yamljs": "^0.3.0"
     }
 }


### PR DESCRIPTION
Typescript is a dev dependency and is not used at runtime. Including it in `dependencies` can prevent packages with loosely declared typescript dependency from upgrading to the latest.