### PR TITLE
Invoke key value store watch observable on unsuccessful upstream connections

### DIFF
--- a/src/main/DynamicConfig.ts
+++ b/src/main/DynamicConfig.ts
@@ -510,9 +510,12 @@ export class DynamicConfig implements IDynamicConfig {
         rootConfig: ConfigValue,
         whitelist?: Array<string>,
     ): Promise<ConfigValue> {
-        const unresolved: Array<
-            PromisedUpdate
-        > = this.collectConfigPlaceholders(rootConfig, [], [], whitelist)
+        const unresolved: Array<PromisedUpdate> = this.collectConfigPlaceholders(
+            rootConfig,
+            [],
+            [],
+            whitelist,
+        )
         const paths: Array<string> = unresolved.map((next: PromisedUpdate) =>
             next[0].join('.'),
         )

--- a/src/main/resolvers/consul.ts
+++ b/src/main/resolvers/consul.ts
@@ -298,7 +298,7 @@ export function consulResolver(): IRemoteResolver {
                                                 })
                                         },
                                         (err: any) => {
-                                            console.warn(
+                                            logger.warn(
                                                 `Unable to resolve address for key[${key}]: ${err.message}.
                                                 Watching key value store for updates.`,
                                             )

--- a/src/main/resolvers/consul.ts
+++ b/src/main/resolvers/consul.ts
@@ -50,7 +50,7 @@ function addTrailingSlash(str: string): string {
     }
 }
 
-function invokeKeyValueStoreWatchFunction(
+function invokeKeyValueStoreWatchObserver(
     callback: WatchFunction,
     client: IConsulClient,
     pathForKey: string,
@@ -281,7 +281,7 @@ export function consulResolver(): IRemoteResolver {
                         .then(
                             (_val: any) => {
                                 if (_val !== null) {
-                                    invokeKeyValueStoreWatchFunction(
+                                    invokeKeyValueStoreWatchObserver(
                                         callback,
                                         client,
                                         pathForKey,
@@ -302,7 +302,7 @@ export function consulResolver(): IRemoteResolver {
                                                 `Unable to resolve address for key[${key}]: ${err.message}.
                                                 Watching key value store for updates.`,
                                             )
-                                            invokeKeyValueStoreWatchFunction(
+                                            invokeKeyValueStoreWatchObserver(
                                                 callback,
                                                 client,
                                                 pathForKey,

--- a/src/main/resolvers/consul.ts
+++ b/src/main/resolvers/consul.ts
@@ -50,6 +50,27 @@ function addTrailingSlash(str: string): string {
     }
 }
 
+function invokeKeyValueStoreWatchFunction(
+    callback: WatchFunction,
+    client: IConsulClient,
+    pathForKey: string,
+    remoteOptions: IRemoteOverrides,
+    consulDc: Maybe<string>,
+) {
+    const observer = client.kvStore.watch({
+        path: pathForKey,
+        dc: remoteOptions.dc || consulDc.getOrElse(''),
+    })
+
+    observer.onValue((val: any) => {
+        callback(undefined, val)
+    })
+
+    observer.onError((err: Error) => {
+        callback(err, undefined)
+    })
+}
+
 interface IConsulClient {
     kvStore: KvStore
     catalog: Catalog
@@ -260,20 +281,13 @@ export function consulResolver(): IRemoteResolver {
                         .then(
                             (_val: any) => {
                                 if (_val !== null) {
-                                    const observer = client.kvStore.watch({
-                                        path: pathForKey,
-                                        dc:
-                                            remoteOptions.dc ||
-                                            consulDc.getOrElse(''),
-                                    })
-
-                                    observer.onValue((val: any) => {
-                                        callback(undefined, val)
-                                    })
-
-                                    observer.onError((err: Error) => {
-                                        callback(err, undefined)
-                                    })
+                                    invokeKeyValueStoreWatchFunction(
+                                        callback,
+                                        client,
+                                        pathForKey,
+                                        remoteOptions,
+                                        consulDc,
+                                    )
                                 } else {
                                     client.catalog.resolveAddress(key).then(
                                         (address: string) => {
@@ -284,11 +298,16 @@ export function consulResolver(): IRemoteResolver {
                                                 })
                                         },
                                         (err: any) => {
-                                            callback(
-                                                new Error(
-                                                    `Unable to watch key[${key}]. ${err.message}`,
-                                                ),
-                                                undefined,
+                                            console.warn(
+                                                `Unable to resolve address for key[${key}]: ${err.message}.
+                                                Watching key value store for updates.`,
+                                            )
+                                            invokeKeyValueStoreWatchFunction(
+                                                callback,
+                                                client,
+                                                pathForKey,
+                                                remoteOptions,
+                                                consulDc,
                                             )
                                         },
                                     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the Consul resolver watch logic to invoke the downstream key value store's watch observable in the instance where:

- The downstream key value store could not be contacted (generally in the case of an HTTP 404), and
- The attempt to resolve the service address via service exploration is unsuccessful

This allows downstream polling to the remote key value store in the instance that a successful connection is established and removes the need for an application restart

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to allow remote 404s to continue polling until a connection can be established. There are use cases where this is a valid scenario and prevents the need for application restarts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested in tandem with changes to [@creditkarma/consul-client](https://github.com/creditkarma/consul-client/pull/23) internally and validated to be working as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes (existing integration test covers the retry scenario).
- [x] All new and existing tests passed.
