### PR TITLE
fix(FWK-2651): Update getRemoteValue to bust cached key value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,95 +1,96 @@
 defaults: &defaults
-  working_directory: ~/dynamic-config
+    working_directory: ~/dynamic-config
 
 helpers:
-  install_node_16: &install_node_16
-    run:
-      name: Install Node 16
-      command: |
-        set +e
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-        export NVM_DIR="/opt/circleci/.nvm"
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-        nvm install 16
-        nvm alias default 16
-        # Each step uses the same `$BASH_ENV`, so need to modify it
-        echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-        echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+    install_node_16: &install_node_16
+        run:
+            name: Install Node 16
+            command: |
+                set +e
+                curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+                export NVM_DIR="/opt/circleci/.nvm"
+                [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+                nvm install 16
+                nvm alias default 16
+                # Each step uses the same `$BASH_ENV`, so need to modify it
+                echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+                echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 
 version: 2
-executorType: machine
+machine: true
+resource_class: large
 jobs:
-  test:
-    <<: *defaults
-    steps:
-      - checkout
-      - *install_node_16
-      - run:
-          name: Install NPM Dependencies
-          command: npm install
-      - run:
-          name: Run Test Suite
-          command: npm test
+    test:
+        <<: *defaults
+        steps:
+            - checkout
+            - *install_node_16
+            - run:
+                  name: Install NPM Dependencies
+                  command: npm install
+            - run:
+                  name: Run Test Suite
+                  command: npm test
 
-  publish:
-    <<: *defaults
-    steps:
-      - checkout
-      - *install_node_16
-      - run:
-          name: Generate .npmrc File
-          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
-      - run:
-          name: Install NPM Dependencies
-          command: npm install
-      - run:
-          name: Build Publish Assets
-          command: npm run build
-      - run:
-          name: Publish to NPM
-          command: npm publish --access public
+    publish:
+        <<: *defaults
+        steps:
+            - checkout
+            - *install_node_16
+            - run:
+                  name: Generate .npmrc File
+                  command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+            - run:
+                  name: Install NPM Dependencies
+                  command: npm install
+            - run:
+                  name: Build Publish Assets
+                  command: npm run build
+            - run:
+                  name: Publish to NPM
+                  command: npm publish --access public
 
-  publish_next:
-    <<: *defaults
-    steps:
-      - checkout
-      - *install_node_16
-      - run:
-          name: Generate .npmrc File
-          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
-      - run:
-          name: Install NPM Dependencies
-          command: npm install
-      - run:
-          name: Build Publish Assets
-          command: npm run build
-      - run:
-          name: Publish to NPM
-          command: npm publish --tag next --access public
+    publish_next:
+        <<: *defaults
+        steps:
+            - checkout
+            - *install_node_16
+            - run:
+                  name: Generate .npmrc File
+                  command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+            - run:
+                  name: Install NPM Dependencies
+                  command: npm install
+            - run:
+                  name: Build Publish Assets
+                  command: npm run build
+            - run:
+                  name: Publish to NPM
+                  command: npm publish --tag next --access public
 
 workflows:
-  version: 2
-  build_publish:
-      jobs:
-        - test:
-            filters:
-              tags:
-                only: /.*/
+    version: 2
+    build_publish:
+        jobs:
+            - test:
+                  filters:
+                      tags:
+                          only: /.*/
 
-        - publish:
-            requires:
-              - test
-            filters:
-              tags:
-                only: /^(v){1}[0-9]+(\.[0-9]+){2}$/
-              branches:
-                ignore: /.*/
+            - publish:
+                  requires:
+                      - test
+                  filters:
+                      tags:
+                          only: /^(v){1}[0-9]+(\.[0-9]+){2}$/
+                      branches:
+                          ignore: /.*/
 
-        - publish_next:
-            requires:
-              - test
-            filters:
-              tags:
-                only: /^(v){1}[0-9]+(\.[0-9]+){2}(-)[0-9]+$/
-              branches:
-                ignore: /.*/
+            - publish_next:
+                  requires:
+                      - test
+                  filters:
+                      tags:
+                          only: /^(v){1}[0-9]+(\.[0-9]+){2}(-)[0-9]+$/
+                      branches:
+                          ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 defaults: &defaults
+    machine: true
+    resource_class: large
     working_directory: ~/dynamic-config
 
 helpers:
@@ -17,11 +19,8 @@ helpers:
                 echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 
 version: 2
-
 jobs:
     test:
-        machine: true
-        resource_class: large
         <<: *defaults
         steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,11 @@ helpers:
                 echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 
 version: 2
-machine: true
-resource_class: large
+
 jobs:
     test:
+        machine: true
+        resource_class: large
         <<: *defaults
         steps:
             - checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
 Thank you for considering contributing to Dynamic Config!
 Please take a moment to review this document to make the contribution process easy and effective.
 
-## Reporting a bug
+<span style=" font-size:2.5em;">Reporting a bug 🐞</span>
 
 Dynamic Config uses github issues to track bugs. Bugs are labelled as [bug](https://github.com/creditkarma/dynamic-config/labels/bug).
 Before reporting a new bug first search the issues to find out if it's already reported and/or resolved and pending merge.
 
 When you create a new bug report please include following information:
 
-* Short description
-* Environment on which you are able to reproduce it
-* Steps to reproduce
+-   Short description
+-   Environment on which you are able to reproduce it
+-   Steps to reproduce
 
-## Feature requests
+<span style="font-size:2.5em;">Feature requests 💁‍♀️</span>
 
 Feature requests are labelled as [enhancement](https://github.com/creditkarma/dynamic-config/labels/enhancement).
 We welcome new feature requests but first find out if a similar request is already in the queue.
 
-## Pull requests (bug fix, features, etc)
+# Pull requests (bug fix, features, etc)
 
 We welcome community contribution and help improving Dynamic Config. Please keep your PRs focused to the scope.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@creditkarma/dynamic-config",
-    "version": "0.9.14",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@creditkarma/dynamic-config",
-            "version": "0.9.14",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@creditkarma/consul-client": "^1.0.0",

--- a/src/main/DynamicConfig.ts
+++ b/src/main/DynamicConfig.ts
@@ -299,13 +299,46 @@ export class DynamicConfig implements IDynamicConfig {
     }
 
     public async getRemoteValue<T>(key: string, type?: ObjectType): Promise<T> {
-        return this.source(key).then((source: ISource) => {
-            if (source.key !== undefined) {
-                return this.getValueFromResolver<T>(source.key, 'remote', type)
-            } else {
-                throw new errors.ResolverUnavailable(key)
-            }
-        })
+        const source = await this.source(key) // get source for key
+        const { key: sourceKey } = source
+        if (!sourceKey) {
+            throw new errors.ResolverUnavailable(key) // throw if key is undefined
+        }
+
+        const resolvedConfig = await this.getConfig() // get the current config (the cached version, that is)
+
+        const value = await this.getValueFromResolver<T>(
+            sourceKey,
+            'remote',
+            type,
+        ) // get new remote value for key
+
+        if (value === null) {
+            throw new errors.ResolverUnavailable(key) // if it doesn't exist, throw
+        }
+
+        const normalizedKey: string = Utils.normalizePath(key) // normalize/format key path
+
+        /*
+         build the normalized key path for the refreshed value to live at.
+         *note*: this is **required** to format the new value into a shape consumable by `setConfig()`.
+         */
+        const builtValue = ConfigBuilder.buildBaseConfigValue(source, value)
+
+        await this.setConfig(
+            ConfigUtils.setValueForKey(
+                normalizedKey,
+                builtValue,
+                resolvedConfig,
+                true,
+            ) as IRootConfigValue,
+        ) // ship the formatted value to be set in the config
+
+        /*
+        return the value we got from the remote source. We _could_ also do a `get()` against the updated config to be sure the value was updated.
+        I can't be sure how much latency it'd add, but I'm inclined to do it anyways instead of doing an optimistic update.
+        */
+        return value
     }
 
     public async getSecretValue<T>(key: string, type?: ObjectType): Promise<T> {

--- a/src/main/DynamicConfig.ts
+++ b/src/main/DynamicConfig.ts
@@ -328,14 +328,14 @@ export class DynamicConfig implements IDynamicConfig {
             value,
         )
 
-        const keyValue = ConfigUtils.setValueForKey(
+        const newConfig = ConfigUtils.setValueForKey(
             normalizedKey,
             builtValue,
             resolvedConfig,
             true,
         )
 
-        await this.setConfig(keyValue as IRootConfigValue) // keyValue the formatted value to be set in the config
+        await this.setConfig(newConfig as IRootConfigValue) // keyValue the formatted value to be set in the config
 
         return value
     }

--- a/src/main/DynamicConfig.ts
+++ b/src/main/DynamicConfig.ts
@@ -313,10 +313,6 @@ export class DynamicConfig implements IDynamicConfig {
             type,
         ) // get new remote value for key
 
-        if (value === null) {
-            throw new errors.ResolverUnavailable(key) // if it doesn't exist, throw
-        }
-
         const normalizedKey: string = Utils.normalizePath(key) // normalize/format key path
 
         /*
@@ -337,7 +333,7 @@ export class DynamicConfig implements IDynamicConfig {
 
         await this.setConfig(newConfig as IRootConfigValue) // keyValue the formatted value to be set in the config
 
-        return value
+        return this.get(key) //re-fetch the value from the updated config to be sure it successfully updated the val.
     }
 
     public async getSecretValue<T>(key: string, type?: ObjectType): Promise<T> {

--- a/src/main/utils/config.ts
+++ b/src/main/utils/config.ts
@@ -87,7 +87,9 @@ export function makeTranslator(
             } catch (err) {
                 throw new InvalidConfigValue(
                     path,
-                    err instanceof Error ? err.message : `Non Error Thrown: ${err}`,
+                    err instanceof Error
+                        ? err.message
+                        : `Non Error Thrown: ${err}`,
                 )
             }
         }, obj)

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -316,6 +316,20 @@ describe('DynamicConfig', () => {
                         expect(actual).to.equal('127.0.0.1:3000')
                     })
             })
+            it('should verify that remote value is updated in cached config', async () => {
+                const oldDestination = await dynamicConfig.get(
+                    'test-service.destination',
+                )
+                // make a call to consul to update to a different value
+                // also will need to revert it. so that's annoying
+                await dynamicConfig.getRemoteValue('test-service.destination')
+
+                const updatedConfigVal = await dynamicConfig.get(
+                    'test-service.destination',
+                )
+
+                expect(oldDestination.to.not.equal(updatedConfigVal))
+            })
         })
 
         describe('getSecretValue', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to allow the successful update of a cached config when the config value for a value is updated in a remote source. 

Previously, when getRemoteValue was called to fetch a fresh value, that value was returned but not persisted or updated in the cache.

In this PR:

`getRemoteValue()` is updated to not only retrieve the refreshed config value, but to also store it in the cached config.

## Motivation and Context
Currently, when a value in a remote source is updated, the value can only be read by using `getRemoteValue()`. The value is not updated in the cached config object. This PR updates that.

## How Has This Been Tested?
Tested locally and with a written test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
