### PR TITLE
fix: Update getRemoteValue to correctly resolve new placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ log
 # Temp files
 tmp
 *.tmp
+
+# Consul files
+consuldata/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@creditkarma/dynamic-config",
-    "version": "1.0.1",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@creditkarma/dynamic-config",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@creditkarma/consul-client": "^1.0.0",

--- a/src/main/DynamicConfig.ts
+++ b/src/main/DynamicConfig.ts
@@ -299,24 +299,29 @@ export class DynamicConfig implements IDynamicConfig {
     }
 
     public async getRemoteValue<T>(key: string, type?: ObjectType): Promise<T> {
-        const source: ISource = await this.source(key) // get source for key
+        // get source for key
+        const source: ISource = await this.source(key)
 
+        // throw if key is undefined
         if (!source.key) {
-            throw new errors.ResolverUnavailable(key) // throw if key is undefined
+            throw new errors.ResolverUnavailable(key)
         }
 
-        const currentConfig: IRootConfigValue = await this.getConfig() // get the current config (the cached version, that is)
+        // get the current config (the cached version, that is)
+        const currentConfig: IRootConfigValue = await this.getConfig()
 
+        // get new remote value for key
         const remoteValue: T = await this.getValueFromResolver<T>(
             source.key,
             'remote',
             type,
-        ) // get new remote value for key
+        )
 
-        // Find any placeholders in the remote value
+        // Find any placeholders in the remote value. This is important for resolving `consul!` pointers.
         const translatedValue = this.translator(remoteValue)
 
-        const normalizedKey: string = Utils.normalizePath(key) // normalize/format key path
+        // normalize/format key path
+        const normalizedKey: string = Utils.normalizePath(key)
 
         /*
          build the normalized key path for the refreshed value to live at.
@@ -330,6 +335,7 @@ export class DynamicConfig implements IDynamicConfig {
         // Resolve any new placeholders in updated config
         const resolvedValue = await this.replaceConfigPlaceholders(builtValue)
 
+        // create shape of new config
         const newConfig = ConfigUtils.setValueForKey(
             normalizedKey,
             resolvedValue as BaseConfigValue,

--- a/src/main/utils/config.ts
+++ b/src/main/utils/config.ts
@@ -392,16 +392,26 @@ function setRootConfigValueForKey(
     return returnValue
 }
 
-export function setValueForKey(
+export function setValueForKey<T extends ConfigValue>(
     key: string,
     newValue: BaseConfigValue,
-    oldConfig: ConfigValue,
+    oldConfig: T,
     alertWatchers: boolean = false,
-): ConfigValue {
+): T {
     if (oldConfig.type === 'root') {
-        return setRootConfigValueForKey(key, newValue, oldConfig, alertWatchers)
+        return setRootConfigValueForKey(
+            key,
+            newValue,
+            oldConfig,
+            alertWatchers,
+        ) as T
     } else {
-        return setBaseConfigValueForKey(key, newValue, oldConfig, alertWatchers)
+        return setBaseConfigValueForKey(
+            key,
+            newValue,
+            oldConfig,
+            alertWatchers,
+        ) as T
     }
 }
 

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -349,7 +349,7 @@ describe('DynamicConfig', () => {
                     'test-service.destination',
                 )
 
-                expect(initialConfigValue).to.equal('http://localhost:8080')
+                expect(initialConfigValue).to.equal('http://localhost:3000')
 
                 // update this for fun
                 await catalog.registerEntity({

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -315,6 +315,8 @@ describe('DynamicConfig', () => {
                     'http://localhost:8510',
                 ])
 
+                const startingConfigVal = await dynamicConfig.get('secret')
+
                 await consulClient.set(
                     { path: 'test-secret', dc: 'dc1' }, // these key paths are weird! lol. Somehow this resolves to 'secret'
                     'this is a new secret',
@@ -334,6 +336,12 @@ describe('DynamicConfig', () => {
             it('should check the value for a remote source repeatedly and verify the remote value is updated in cached config', async () => {
                 // make a call to consul to update to a different value
                 const catalog = new Catalog(['http://localhost:8510'])
+
+                const initialConfigValue = await dynamicConfig.get(
+                    'test-service.destination',
+                )
+
+                expect(initialConfigValue).to.equal('http://localhost:8080')
 
                 // update this for fun
                 await catalog.registerEntity({
@@ -380,6 +388,8 @@ describe('DynamicConfig', () => {
                         Port: 3000,
                     },
                 })
+
+                expect(updatedTwiceConfigVal).to.equal('127.0.0.1:3000')
             })
             it('should return value from remote source', async () => {
                 return dynamicConfig

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -309,6 +309,78 @@ describe('DynamicConfig', () => {
         })
 
         describe('getRemoteValue', () => {
+            it('should verify that remote value is updated in cached config', async () => {
+                // make a call to consul to update to a different value
+                const consulClient: KvStore = new KvStore([
+                    'http://localhost:8510',
+                ])
+
+                await consulClient.set(
+                    { path: 'test-secret', dc: 'dc1' }, // these key paths are weird! lol. Somehow this resolves to 'secret'
+                    'this is a new secret',
+                )
+
+                await dynamicConfig.getRemoteValue('secret')
+
+                const updatedConfigVal = await dynamicConfig.get('secret')
+
+                expect(updatedConfigVal).to.equal('this is a new secret')
+
+                await consulClient.set(
+                    { path: 'test-secret', dc: 'dc1' },
+                    'this is a secret',
+                )
+            })
+            it('should check the value for a remote source repeatedly and verify the remote value is updated in cached config', async () => {
+                // make a call to consul to update to a different value
+                const catalog = new Catalog(['http://localhost:8510'])
+
+                // update this for fun
+                await catalog.registerEntity({
+                    Node: 'bango',
+                    Address: '192.168.4.19',
+                    Service: {
+                        Service: 'test-service',
+                        Address: '127.0.0.1',
+                        Port: 8888,
+                    },
+                })
+
+                await dynamicConfig.getRemoteValue('test-service.destination')
+                const updatedOnceConfigVal = await dynamicConfig.get(
+                    'test-service.destination',
+                )
+
+                expect(updatedOnceConfigVal).to.equal('127.0.0.1:8888')
+
+                await catalog.registerEntity({
+                    Node: 'bango',
+                    Address: '192.168.4.19',
+                    Service: {
+                        Service: 'test-service',
+                        Address: '127.0.0.1',
+                        Port: 9999,
+                    },
+                })
+
+                await dynamicConfig.getRemoteValue('test-service.destination')
+
+                const updatedTwiceConfigVal = await dynamicConfig.get(
+                    'test-service.destination',
+                )
+
+                expect(updatedTwiceConfigVal).to.equal('127.0.0.1:9999')
+
+                await catalog.registerEntity({
+                    Node: 'bango',
+                    Address: '192.168.4.19',
+                    Service: {
+                        Service: 'test-service',
+                        Address: '127.0.0.1',
+                        Port: 3000,
+                    },
+                })
+            })
             it('should return value from remote source', async () => {
                 return dynamicConfig
                     .getRemoteValue('test-service.destination')

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -351,7 +351,7 @@ describe('DynamicConfig', () => {
                     'test-service.destination',
                 )
 
-                expect(initialConfigValue).to.equal('http://127.0.0.1:3000')
+                expect(initialConfigValue).to.equal('127.0.0.1:3000')
 
                 // update this for fun
                 await catalog.registerEntity({

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -315,7 +315,11 @@ describe('DynamicConfig', () => {
                     'http://localhost:8510',
                 ])
 
-                const startingConfigVal = await dynamicConfig.get('secret')
+                const initialConfigValue = await dynamicConfig.get(
+                    'secret',
+                )
+
+                expect(initialConfigValue).to.equal('this is a secret')
 
                 await consulClient.set(
                     { path: 'test-secret', dc: 'dc1' }, // these key paths are weird! lol. Somehow this resolves to 'secret'
@@ -332,6 +336,10 @@ describe('DynamicConfig', () => {
                     { path: 'test-secret', dc: 'dc1' },
                     'this is a secret',
                 )
+
+                const restoredConfigVal = await dynamicConfig.get('secret')
+
+                expect(restoredConfigVal).to.equal('this is a secret')
             })
             it('should check the value for a remote source repeatedly and verify the remote value is updated in cached config', async () => {
                 // make a call to consul to update to a different value
@@ -389,7 +397,11 @@ describe('DynamicConfig', () => {
                     },
                 })
 
-                expect(updatedTwiceConfigVal).to.equal('127.0.0.1:3000')
+                const restoredConfigVal = await dynamicConfig.get(
+                    'test-service.destination',
+                )
+
+                expect(restoredConfigVal).to.equal('127.0.0.1:3000')
             })
             it('should return value from remote source', async () => {
                 return dynamicConfig

--- a/src/tests/integration/DynamicConfig.spec.ts
+++ b/src/tests/integration/DynamicConfig.spec.ts
@@ -337,6 +337,8 @@ describe('DynamicConfig', () => {
                     'this is a secret',
                 )
 
+                await dynamicConfig.getRemoteValue('secret')
+
                 const restoredConfigVal = await dynamicConfig.get('secret')
 
                 expect(restoredConfigVal).to.equal('this is a secret')
@@ -349,7 +351,7 @@ describe('DynamicConfig', () => {
                     'test-service.destination',
                 )
 
-                expect(initialConfigValue).to.equal('http://localhost:3000')
+                expect(initialConfigValue).to.equal('http://127.0.0.1:3000')
 
                 // update this for fun
                 await catalog.registerEntity({
@@ -396,6 +398,8 @@ describe('DynamicConfig', () => {
                         Port: 3000,
                     },
                 })
+
+                await dynamicConfig.getRemoteValue('test-service.destination')
 
                 const restoredConfigVal = await dynamicConfig.get(
                     'test-service.destination',


### PR DESCRIPTION
## Description
Previously the getRemoteValue function would only try to grab a new value from a registered remote. The value would not be persisted so that subsequent calls to get would get the new value. This updates getRemoteValue to persist new values. Additionally we were not resolving placeholders that may exist in the new value. This retrieves a new value, resolves any placeholders that may exist and then persists the resolved value back to the cached config.

## Motivation and Context
This solves a bug where bad/out-of-date values remained in the config even after we know they have been updated.

## How Has This Been Tested?
New integration tests have been added to verify that a value can be updated and that the updated value is persisted in the config cache.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
