### PR TITLE
feat: Adding support for alternative key lookup incase if original key lookup failed

### DIFF
--- a/docs/config-resolution.md
+++ b/docs/config-resolution.md
@@ -157,6 +157,7 @@ The interface:
 interface IConfigPlaceholder {
     _source: string
     _key: string
+    _altKey?: string
     _default?: any
     _type?: 'string' | 'number' | 'object' | 'array' | 'boolean'
     _nullable?: boolean
@@ -165,6 +166,7 @@ interface IConfigPlaceholder {
 
 * `_source` - The name of the resolver to process the key.
 * `_key` - A string to ask the resolver for.
+* `_altKey` - A string incase of the original _key is not resolved/configured in the source
 * `_default` - A default value for the case that placeholder resolution fails. Default values are ignored for resolvers that are registered as 'secret' stores.
 * `_type` - Indicates how to try to parse this value. If no type is provided then the raw value returned from the source is used (usually a string). This value is given to the underlying resolver to make decisions. Some resolvers (as is the case with included Consul and Vault resolvers) may choose to ignore the `_type` property.
 * `_nullable` - Indicates that the value may be missing. In this case if someone calls `get` for a nullable key `null` will be returned as the expected value of the key. Usually if they value is not found an error is raised.

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -107,8 +107,13 @@ export interface IRemoteResolver {
     type: ResolverType
     name: string
     init: RemoteInitializer
-    get<T>(key: string, type?: ObjectType): Promise<T>
-    watch<T>(key: string, cb: WatchFunction<T>, type?: ObjectType): void
+    get<T>(key: string, type?: ObjectType, altKey?: string): Promise<T>
+    watch<T>(
+        key: string,
+        cb: WatchFunction<T>,
+        type?: ObjectType,
+        altKey?: string,
+    ): void
 }
 
 // CONFIG TYPES
@@ -119,6 +124,7 @@ export interface ISource {
     type: SourceType
     name: string
     key?: string
+    altKey?: string
 }
 
 export type ConfigType = 'root' | ObjectType | DeferredType | InvalidType
@@ -228,6 +234,7 @@ export interface IConfigPlaceholder {
     _type?: ObjectType
     _default?: any
     _nullable?: boolean
+    _altKey?: string
 }
 
 /**
@@ -245,6 +252,7 @@ export interface IResolvedPlaceholder {
     type: ObjectType
     nullable: boolean
     default?: any
+    altKey?: string
 }
 
 // UTILITY TYPES

--- a/src/main/utils/config.ts
+++ b/src/main/utils/config.ts
@@ -149,6 +149,7 @@ export function normalizeConfigPlaceholder(
         return {
             path: path.join('.'),
             key: placeholder._key,
+            altKey: placeholder._altKey,
             resolver: {
                 name: source,
                 type: resolver.type,
@@ -170,6 +171,9 @@ export function isConfigPlaceholder(obj: any): obj is IConfigPlaceholder {
             type: 'object',
             properties: {
                 _key: {
+                    type: 'string',
+                },
+                _altKey: {
                     type: 'string',
                 },
                 _source: {

--- a/src/main/utils/promises.ts
+++ b/src/main/utils/promises.ts
@@ -80,9 +80,8 @@ export function race(promises: Array<Promise<any>>): Promise<any> {
                 (err: any) => {
                     current++
                     if (!resolved && current === count) {
-                        reject(
-                            new Error('All Promises rejected without success'),
-                        )
+                        // Propagate the last promise error back to caller
+                        reject(err)
                     }
                 },
             )

--- a/src/tests/integration/bootstrap.ts
+++ b/src/tests/integration/bootstrap.ts
@@ -192,6 +192,42 @@ setTimeout(() => {
                 },
             ),
             consulClient.set(
+                { path: 'with-vault-altkey' },
+                {
+                    persistedQueries: {
+                        databaseLookup: {
+                            password: {
+                                _source: 'vault',
+                                _key: 'password',
+                            },
+                        },
+                        databaseWithAlternativeKeyLookup: {
+                            password: {
+                                _source: 'vault',
+                                _key: 'nonexistingkey',
+                                _altKey: 'password',
+                            },
+                        },
+                    },
+                    'hashicorp-vault': {
+                        apiVersion: 'v1',
+                        protocol: 'http',
+                        destination: 'localhost:8210',
+                        mount: 'secret',
+                        tokenPath: './tmp/token',
+                    },
+                    secret: {
+                        _source: 'vault',
+                        _key: 'test-secret',
+                    },
+                    secretWithAlternativeKeyLookup: {
+                        _source: 'vault',
+                        _key: 'nonexistingsecretkey',
+                        _altKey: 'test-secret',
+                    },
+                },
+            ),
+            consulClient.set(
                 { path: 'service/toggles' },
                 {
                     toggles: [

--- a/src/tests/integration/resolvers/customConsul.ts
+++ b/src/tests/integration/resolvers/customConsul.ts
@@ -1,0 +1,379 @@
+import { Catalog, KvStore } from '@creditkarma/consul-client'
+
+import { Just, Maybe, Nothing } from '../../../main/Maybe'
+
+import {
+    CONSUL_ADDRESS,
+    CONSUL_DC,
+    CONSUL_KEYS,
+    CONSUL_NAMESPACE,
+} from '../../../main/constants'
+
+import * as errors from '../../../main/errors'
+
+import {
+    IConfigStore,
+    IConsulOptions,
+    IRemoteOverrides,
+    IRemoteResolver,
+    ObjectType,
+    WatchFunction,
+} from '../../../main/types'
+
+import { ObjectUtils, PromiseUtils, Utils } from '../../../main/utils'
+
+import { defaultLogger as logger } from '../../../main/logger'
+
+export function toRemoteOptionMap(str: string): IRemoteOverrides {
+    const [key, ...tail] = str.split('?')
+    const result: IRemoteOverrides = { key }
+
+    if (tail.length > 0) {
+        const params = tail[0]
+        const options = params.split('&')
+        for (const option of options) {
+            const [name, value] = option.split('=')
+            if (value !== undefined) {
+                result[name] = value
+            }
+        }
+    }
+
+    return result
+}
+
+function addTrailingSlash(str: string): string {
+    if (str.endsWith('/')) {
+        return str
+    } else {
+        return `${str}/`
+    }
+}
+
+function invokeKeyValueStoreWatchObserver(
+    callback: WatchFunction,
+    client: IConsulClient,
+    pathForKey: string,
+    remoteOptions: IRemoteOverrides,
+    consulDc: Maybe<string>,
+) {
+    const observer = client.kvStore.watch({
+        path: pathForKey,
+        dc: remoteOptions.dc || consulDc.getOrElse(''),
+    })
+
+    observer.onValue((val: any) => {
+        callback(undefined, val)
+    })
+
+    observer.onError((err: Error) => {
+        callback(err, undefined)
+    })
+}
+
+interface IConsulClient {
+    kvStore: KvStore
+    catalog: Catalog
+}
+
+export function customConsulResolver(): IRemoteResolver {
+    let consulClient: Maybe<IConsulClient>
+    let consulAddress: Maybe<string> = new Nothing()
+    let consulDc: Maybe<string> = new Nothing()
+    let consulKeys: Maybe<string> = new Nothing()
+    let consulNamespace: Maybe<string> = new Nothing()
+
+    function getConsulClient(): Maybe<IConsulClient> {
+        if (consulClient !== undefined) {
+            return consulClient
+        } else {
+            if (consulAddress.isNothing()) {
+                logger.warn(
+                    'Could not create a Consul client: Consul Address (CONSUL_ADDRESS) is not defined',
+                )
+                consulClient = new Nothing<IConsulClient>()
+            } else if (consulDc.isNothing()) {
+                logger.warn(
+                    'Could not create a Consul client: Consul Data Center (CONSUL_DC) is not defined',
+                )
+                consulClient = new Nothing<IConsulClient>()
+            } else {
+                const addresses: Array<string> = consulAddress
+                    .get()
+                    .split(',')
+                    .map((next: string) => {
+                        return next.trim()
+                    })
+                    .filter((next: string) => {
+                        return next !== ''
+                    })
+
+                consulClient = new Just({
+                    kvStore: new KvStore(addresses),
+                    catalog: new Catalog(addresses),
+                })
+            }
+
+            return consulClient
+        }
+    }
+
+    return {
+        type: 'remote',
+        name: 'consul',
+
+        async init(
+            configInstance: IConfigStore,
+            remoteOptions: IConsulOptions = {},
+        ): Promise<any> {
+            consulAddress = Maybe.fromNullable(
+                remoteOptions.consulAddress ||
+                    Utils.readFirstMatch(CONSUL_ADDRESS),
+            )
+
+            consulDc = Maybe.fromNullable(
+                remoteOptions.consulDc || Utils.readFirstMatch(CONSUL_DC),
+            )
+
+            consulKeys = Maybe.fromNullable(
+                remoteOptions.consulKeys || Utils.readFirstMatch(CONSUL_KEYS),
+            )
+
+            consulNamespace = Maybe.fromNullable(
+                remoteOptions.consulNamespace ||
+                    Utils.readFirstMatch(CONSUL_NAMESPACE),
+            )
+
+            return Maybe.all(getConsulClient(), consulDc).fork(
+                // Some case
+                ([client, dc]) => {
+                    const keys: string = consulKeys.getOrElse('')
+
+                    if (keys !== '') {
+                        const rawConfigs: Promise<Array<any>> = Promise.all(
+                            keys.split(',').map((key: string) => {
+                                return client.kvStore
+                                    .get({ path: key, dc })
+                                    .then((val: any) => {
+                                        if (val === null) {
+                                            throw new Error(
+                                                `Unable to find key[${key}] in Consul.`,
+                                            )
+                                        } else {
+                                            return val
+                                        }
+                                    })
+                            }),
+                        ).catch((err: any) => {
+                            logger.error(
+                                `Unable to read keys[${keys}] from Consul. ${err.message}`,
+                            )
+                            return []
+                        })
+
+                        const resolvedConfigs: Promise<any> = rawConfigs.then(
+                            (configs: Array<any>): any => {
+                                return ObjectUtils.overlayObjects(
+                                    ...configs,
+                                ) as any
+                            },
+                        )
+
+                        return resolvedConfigs
+                    } else {
+                        logger.log('No keys to load from Consul.')
+                        return {}
+                    }
+                },
+                // Nothing case
+                () => {
+                    logger.log('Consul is not configured.')
+                    return {}
+                },
+            )
+        },
+
+        async get<T = any>(
+            key: string,
+            type?: ObjectType,
+            altKey?: string,
+        ): Promise<T> {
+            return getConsulClient().fork(
+                // Some case
+                (client: IConsulClient) => {
+                    const keys = [key]
+                    if (altKey !== undefined) {
+                        keys.push(altKey)
+                    }
+                    return PromiseUtils.race(
+                        keys.map((key) => {
+                            const remoteOptions: IRemoteOverrides =
+                                toRemoteOptionMap(key)
+
+                            return client.kvStore
+                                .get({
+                                    path: consulNamespace.fork(
+                                        // Some case
+                                        (val: string) => {
+                                            return `${addTrailingSlash(val)}${
+                                                remoteOptions.key
+                                            }`
+                                        },
+                                        // Nothing case
+                                        () => {
+                                            return `${remoteOptions.key}`
+                                        },
+                                    ),
+                                    dc:
+                                        remoteOptions.dc ||
+                                        consulDc.getOrElse(''),
+                                })
+                                .then(
+                                    (val: any) => {
+                                        if (val !== null) {
+                                            return val
+                                        } else {
+                                            return client.catalog
+                                                .resolveAddress(key)
+                                                .then(
+                                                    (address: string) => {
+                                                        return address
+                                                    },
+                                                    (err: Error) => {
+                                                        throw new errors.ConsulFailed(
+                                                            key,
+                                                            err.message,
+                                                        )
+                                                    },
+                                                )
+                                        }
+                                    },
+                                    (err: any) => {
+                                        throw new errors.ConsulFailed(
+                                            key,
+                                            err.message,
+                                        )
+                                    },
+                                )
+                        }),
+                    ).then(
+                        (val: any) => {
+                            return val
+                        },
+                        (err: any) => {
+                            throw err
+                        },
+                    )
+                },
+                // Nothing case
+                () => {
+                    throw new errors.ConsulNotConfigured(key)
+                },
+            )
+        },
+
+        watch<T = any>(
+            key: string,
+            callback: WatchFunction<T>,
+            type?: ObjectType,
+            altKey?: string,
+        ): void {
+            getConsulClient().fork(
+                (client: IConsulClient) => {
+                    const keys = [key]
+                    if (altKey !== undefined) {
+                        keys.push(altKey)
+                    }
+                    PromiseUtils.race(
+                        keys.map((key) => {
+                            const remoteOptions: IRemoteOverrides =
+                                toRemoteOptionMap(key)
+
+                            const pathForKey = consulNamespace.fork(
+                                // Some case
+                                (val: string) => {
+                                    return `${addTrailingSlash(val)}${
+                                        remoteOptions.key
+                                    }`
+                                },
+                                // Nothing case
+                                () => {
+                                    return `${remoteOptions.key}`
+                                },
+                            )
+
+                            return client.kvStore.get({
+                                path: pathForKey,
+                                dc: remoteOptions.dc || consulDc.getOrElse(''),
+                            })
+                        }),
+                    ).then(
+                        (val: any) => {
+                            const remoteOptions: IRemoteOverrides =
+                                toRemoteOptionMap(key)
+
+                            const pathForKey = consulNamespace.fork(
+                                // Some case
+                                (val: string) => {
+                                    return `${addTrailingSlash(val)}${
+                                        remoteOptions.key
+                                    }`
+                                },
+                                // Nothing case
+                                () => {
+                                    return `${remoteOptions.key}`
+                                },
+                            )
+
+                            if (val !== null) {
+                                invokeKeyValueStoreWatchObserver(
+                                    callback,
+                                    client,
+                                    pathForKey,
+                                    remoteOptions,
+                                    consulDc,
+                                )
+                            } else {
+                                client.catalog.resolveAddress(key).then(
+                                    (address: string) => {
+                                        client.catalog
+                                            .watchAddress(key)
+                                            .onValue((val: any) => {
+                                                callback(undefined, val)
+                                            })
+                                    },
+                                    (err: any) => {
+                                        logger.warn(
+                                            `Unable to resolve address for key[${key}]: ${err.message}.
+                                        Watching key value store for updates.`,
+                                        )
+                                        invokeKeyValueStoreWatchObserver(
+                                            callback,
+                                            client,
+                                            pathForKey,
+                                            remoteOptions,
+                                            consulDc,
+                                        )
+                                    },
+                                )
+                            }
+                        },
+                        (err: any) => {
+                            callback(
+                                new Error(
+                                    `Unable to watch key[${key}]. ${err.message}`,
+                                ),
+                                undefined,
+                            )
+                        },
+                    )
+                },
+                () => {
+                    logger.warn(
+                        `Unable to watch changes for key[${key}]. Consul is not configured.`,
+                    )
+                },
+            )
+        },
+    }
+}

--- a/src/tests/integration/resolvers/customVault.ts
+++ b/src/tests/integration/resolvers/customVault.ts
@@ -1,0 +1,89 @@
+import { IHVConfig, VaultClient } from '@creditkarma/vault-client'
+
+import { HVAULT_CONFIG_KEY } from '../../../main/constants'
+
+import { Just, Maybe, Nothing } from '../../../main/Maybe'
+
+import * as errors from '../../../main/errors'
+
+import {
+    IConfigStore,
+    IRemoteResolver,
+    ObjectType,
+    WatchFunction,
+} from '../../../main/types'
+
+import { defaultLogger as logger } from '../../../main/logger'
+import { PromiseUtils } from '../../../main/utils'
+
+export function customVaultResolver(): IRemoteResolver {
+    let vaultClient: Maybe<VaultClient> | null = null
+    let vaultConfig: IHVConfig | null = null
+
+    async function getVaultClient(): Promise<Maybe<VaultClient>> {
+        if (vaultClient !== null) {
+            return vaultClient
+        } else {
+            if (vaultConfig !== null) {
+                vaultClient = new Just(new VaultClient(vaultConfig))
+                logger.log(`Vault client initialized for secret config store.`)
+            } else {
+                logger.warn(`Unable to find valid configuration for Vault.`)
+                vaultClient = new Nothing<VaultClient>()
+            }
+
+            return vaultClient
+        }
+    }
+
+    return {
+        type: 'secret',
+        name: 'vault',
+
+        init(
+            configInstance: IConfigStore,
+            remoteOptions: any = {},
+        ): Promise<any> {
+            vaultConfig = configInstance.get<IHVConfig>(HVAULT_CONFIG_KEY)
+            return Promise.resolve({})
+        },
+
+        async get<T>(
+            key: string,
+            type?: ObjectType,
+            altKey?: string,
+        ): Promise<T> {
+            return getVaultClient().then((maybeClient: Maybe<VaultClient>) => {
+                return maybeClient.fork(
+                    (client: VaultClient) => {
+                        const keys = [key]
+                        if (typeof altKey == 'string') {
+                            keys.push(altKey)
+                        }
+                        return PromiseUtils.race(
+                            keys.map((key) => client.get<T>(key)),
+                        ).then(
+                            (value: T) => {
+                                return Promise.resolve(value)
+                            },
+                            (err: any) => {
+                                throw new errors.HVFailed(err.message)
+                            },
+                        )
+                    },
+                    () => {
+                        throw new errors.HVNotConfigured(key)
+                    },
+                )
+            })
+        },
+
+        watch<T = any>(
+            key: string,
+            cb: WatchFunction<T>,
+            type?: ObjectType,
+        ): void {
+            // Nothing to do. Can't watch environment variables.
+        },
+    }
+}

--- a/src/tests/integration/resolvers/index.ts
+++ b/src/tests/integration/resolvers/index.ts
@@ -1,0 +1,2 @@
+export { customConsulResolver } from './customConsul'
+export { customVaultResolver } from './customVault'

--- a/src/tests/unit/utils/promises.spec.ts
+++ b/src/tests/unit/utils/promises.spec.ts
@@ -44,9 +44,7 @@ describe('PromiseUtils', () => {
                     Promise.reject(new Error('Promise should reject'))
                 },
                 (err: any) => {
-                    expect(err.message).to.equal(
-                        'All Promises rejected without success',
-                    )
+                    expect(err).to.equal('error 3')
                 },
             )
         })


### PR DESCRIPTION

For placeholders config, these changes allow us to lookup using alternative incase if the original is not resolved against the source

## Description
There are use-cases during the migration from one remote system to an other remote system, often secrets needs to be copied, but they might copied to different secret keys. In such cases, these changes will allow us to lookup for seamless transition and allow fallback incase If the new system failed to load config.

## Motivation and Context
To allow seamless migration of remote source from one system to an other system

## How Has This Been Tested?
Unit and Integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
